### PR TITLE
Dynamic comments loading & placing add comment above

### DIFF
--- a/frontend/src/components/Content/CommentItem.tsx
+++ b/frontend/src/components/Content/CommentItem.tsx
@@ -5,6 +5,7 @@ import { MdDelete, MdEdit } from "react-icons/md";
 import { UserModel } from "../../models/UserModel";
 import { CommentModel } from "../../models/commentModel";
 import * as BlogsApi from "../../network/blogs_api";
+import { formatDate } from "../../utils/formatDate";
 
 interface CommentItemProps {
   comment: CommentModel;
@@ -33,7 +34,7 @@ const CommentItem = ({
   console.log("CommentItem component rendered");
 
   return (
-    <Card className="mb-1 p-0">
+    commentUser && <Card className="mb-1 p-0">
       <Row>
         <Col>
           <Card.Title as={"h6"} className="w-auto ms-1 mt-1">

--- a/frontend/src/components/Content/CommentsModal.tsx
+++ b/frontend/src/components/Content/CommentsModal.tsx
@@ -81,29 +81,7 @@ const CommentsModal = ({
         <Modal.Title>Comments</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        {currentComments.length > 0 ? (
-          currentComments.map((comment) => (
-            <CommentItem
-              comment={comment}
-              key={comment._id}
-              blogUserId={blog.userId}
-              loggedInUserId={loggedInUserId}
-              deleteComment={() => {
-                deleteComment(comment._id, blog._id ? blog._id : "");
-              }}
-              editComment={() => {
-                setIsAdding(false);
-                setValue("commentText", comment.commentText);
-                setCommentId(comment._id);
-              }}
-            />
-          ))
-        ) : (
-          <div className="text-center">No comments yet</div>
-        )}
-      </Modal.Body>
-      <Modal.Footer>
-        <Form onSubmit={handleSubmit(onSubmit)} className="w-100">
+      <Form onSubmit={handleSubmit(onSubmit)} className="w-100">
           <Row className="m-1">
             <Col xs={9} className="m-0">
               <TextInputField
@@ -130,6 +108,29 @@ const CommentsModal = ({
             </Col>
           </Row>
         </Form>
+        {currentComments.length > 0 ? (
+          currentComments.map((comment) => (
+            <CommentItem
+              comment={comment}
+              key={comment._id}
+              blogUserId={blog.userId}
+              loggedInUserId={loggedInUserId}
+              deleteComment={() => {
+                deleteComment(comment._id, blog._id ? blog._id : "");
+              }}
+              editComment={() => {
+                setIsAdding(false);
+                setValue("commentText", comment.commentText);
+                setCommentId(comment._id);
+              }}
+            />
+          ))
+        ) : (
+          <div className="text-center">No comments yet</div>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        
       </Modal.Footer>
     </Modal>
   );


### PR DESCRIPTION
### 2 changes.
1. Before, individual comments were rendered instantly as comments were passed by parent but user details needs to be fetched from server asynchronously, so it is taking some time to show the user name who commented but the comment text is visible the moment item got rendered. _**_Now entire comment item is invisible as long as the user details are not fetched from the server._**_
2. Before, add comments form was at the bottom of **comments modal**. In case there is large no comments, user need to scroll down to add a comment. **Now the same has been shifted to the top** so that user does not need to scroll to add a comment.